### PR TITLE
YouTube Integration Improvements and Code Cleanup

### DIFF
--- a/perspectize-be/Controllers/YTController.cs
+++ b/perspectize-be/Controllers/YTController.cs
@@ -52,15 +52,6 @@ namespace perspectize_be.Controllers
             }
         }
         
-        [HttpPost("video")] // TODO: delete as less complete duplicate of POST /videos - want Don't Repeat Yourself code  
-        public IActionResult PostVideo([FromBody] VideoRequest req, CancellationToken cancellationToken)
-        {
-            if (string.IsNullOrEmpty(req.VideoId)) return BadRequest(new { message = "videoId is required" });
-            return Ok(
-                new { message = $"Video '{req.VideoId}' posted successfully" }
-            );
-        }
-
         [HttpPost("videos")]
         public async Task<IActionResult> PostVideos([FromBody] VideosRequest request, CancellationToken cancellationToken)
         {

--- a/perspectize-be/Models/Content.cs
+++ b/perspectize-be/Models/Content.cs
@@ -27,7 +27,7 @@ namespace perspectize_be.Models
 
         [Column("content_type")]
         [Required]
-        public string ContentType { get; set; } = "youtube"; //TODO: remove default value
+        public string ContentType { get; set; } = string.Empty;
 
         [Column("name")]
         [Required]

--- a/perspectize-be/perspectize-be.csproj
+++ b/perspectize-be/perspectize-be.csproj
@@ -10,7 +10,6 @@
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
**Changes Made**

- Removed duplicate PostVideo endpoint from YTController
- Removed hardcoded "youtube" default value 
- Removed unnecessary SQL Server package reference 

**Testing**
I've tested these changes locally and everything works as expected.

**Future TODOs Noted**

- Several TODOs remain in the codebase for future work
- Use PostgreSQL's ON CONFLICT for upserts instead of our current approach
- The PUT /videos endpoint needs to be updated to use a direct update method

